### PR TITLE
pr: fix critical error introduced by yours truly

### DIFF
--- a/api/src/main/java/com/grash/model/enums/Language.java
+++ b/api/src/main/java/com/grash/model/enums/Language.java
@@ -1,6 +1,7 @@
 package com.grash.model.enums;
 
 public enum Language {
+    DE,
     EN,
     FR,
     TR,


### PR DESCRIPTION
fix: CRITICAL backend crashes after introducing new translation strings. Add DE to enum in com.grash.model.enums to fix crash, appears to work well.