### PR TITLE
slide out page:  give some flexablity on the size better on mobile

### DIFF
--- a/frontend/src/content/own/Inventory/Parts.tsx
+++ b/frontend/src/content/own/Inventory/Parts.tsx
@@ -803,7 +803,7 @@ const Parts = ({ setAction }: PropsType) => {
         open={openDrawer}
         onClose={handleCloseDetails}
         PaperProps={{
-          sx: { width: '50%' }
+          sx: { width: { xs: '90%', sm: '70%', md: '50%' } }
         }}
       >
         <PartDetails

--- a/frontend/src/content/own/Inventory/Sets.tsx
+++ b/frontend/src/content/own/Inventory/Sets.tsx
@@ -394,7 +394,7 @@ const Sets = ({ setAction }: PropsType) => {
         open={openDrawer}
         onClose={handleCloseDetails}
         PaperProps={{
-          sx: { width: '50%' }
+          sx: { width: { xs: '90%', sm: '70%', md: '50%' } }
         }}
       >
         <SetDetails

--- a/frontend/src/content/own/Locations/index.tsx
+++ b/frontend/src/content/own/Locations/index.tsx
@@ -832,7 +832,7 @@ function Locations() {
           open={openDrawer}
           onClose={handleCloseDetails}
           PaperProps={{
-            sx: { width: '50%' }
+            sx: { width: { xs: '90%', sm: '70%', md: '50%' } }
           }}
         >
           <LocationDetails

--- a/frontend/src/content/own/Meters/index.tsx
+++ b/frontend/src/content/own/Meters/index.tsx
@@ -653,7 +653,7 @@ function Meters() {
             open={openDrawer}
             onClose={handleCloseDetails}
             PaperProps={{
-              sx: { width: '50%' }
+              sx: { width: { xs: '90%', sm: '70%', md: '50%' } }
             }}
           >
             <MeterDetails

--- a/frontend/src/content/own/PreventiveMaintenance/index.tsx
+++ b/frontend/src/content/own/PreventiveMaintenance/index.tsx
@@ -817,7 +817,7 @@ function PMs() {
           open={openDrawer}
           onClose={handleCloseDetails}
           PaperProps={{
-            sx: { width: '50%' }
+            sx: { width: { xs: '90%', sm: '70%', md: '50%' } }
           }}
         >
           <PMDetails

--- a/frontend/src/content/own/PurchaseOrders/index.tsx
+++ b/frontend/src/content/own/PurchaseOrders/index.tsx
@@ -589,7 +589,7 @@ function PurchaseOrders() {
             open={openDrawer}
             onClose={handleCloseDetails}
             PaperProps={{
-              sx: { width: '50%' }
+              sx: { width: { xs: '90%', sm: '70%', md: '50%' } }
             }}
           >
             <PurchaseOrderDetails

--- a/frontend/src/content/own/Requests/index.tsx
+++ b/frontend/src/content/own/Requests/index.tsx
@@ -596,7 +596,7 @@ function Files() {
           open={openDrawer}
           onClose={handleCloseDetails}
           PaperProps={{
-            sx: { width: '50%' }
+            sx: { width: { xs: '90%', sm: '70%', md: '50%' } }
           }}
         >
           <RequestDetails

--- a/frontend/src/content/own/Settings/Roles/index.tsx
+++ b/frontend/src/content/own/Settings/Roles/index.tsx
@@ -496,7 +496,7 @@ function Roles() {
         open={openDrawer}
         onClose={() => setOpenDrawer(false)}
         PaperProps={{
-          sx: { width: '50%' }
+          sx: { width: { xs: '90%', sm: '70%', md: '50%' } }
         }}
       >
         <RoleDetails

--- a/frontend/src/content/own/WorkOrders/index.tsx
+++ b/frontend/src/content/own/WorkOrders/index.tsx
@@ -1058,7 +1058,7 @@ function WorkOrders() {
         open={openDrawer}
         onClose={handleCloseDetails}
         PaperProps={{
-          sx: { width: '50%' }
+          sx: { width: { xs: '90%', sm: '70%', md: '50%' } }
         }}
       >
         <WorkOrderDetails


### PR DESCRIPTION
On the phone when you click on a work order, etc and the slide page comes out,  Give it some flexibility to look better on mobile with taking up more of the screen but yet still have the ability to click away. 