### PR TITLE
assets: prevent stale search results from overwriting latest query

### DIFF
--- a/frontend/src/slices/asset.ts
+++ b/frontend/src/slices/asset.ts
@@ -14,6 +14,7 @@ import {
 import { revertAll } from 'src/utils/redux';
 
 const basePath = 'assets';
+let latestAssetsSearchRequestId = 0;
 interface AssetState {
   assets: Page<AssetDTO>;
   assetsHierarchy: AssetRow[];
@@ -151,15 +152,20 @@ export const reducer = slice.reducer;
 export const getAssets =
   (criteria: SearchCriteria): AppThunk =>
   async (dispatch) => {
+    const requestId = ++latestAssetsSearchRequestId;
     try {
       dispatch(slice.actions.setLoadingGet({ loading: true }));
       const assets = await api.post<Page<AssetDTO>>(
         `${basePath}/search`,
         criteria
       );
-      dispatch(slice.actions.getAssets({ assets }));
+      if (requestId === latestAssetsSearchRequestId) {
+        dispatch(slice.actions.getAssets({ assets }));
+      }
     } finally {
-      dispatch(slice.actions.setLoadingGet({ loading: false }));
+      if (requestId === latestAssetsSearchRequestId) {
+        dispatch(slice.actions.setLoadingGet({ loading: false }));
+      }
     }
   };
 export const getAssetsMini =


### PR DESCRIPTION
This change fixes a race condition in asset search where out-of-order API responses could replace newer filtered results (for example after typing a search and then sorting).

Only the latest in-flight search response is now allowed to update the asset list and loading state, keeping results consistent with
 the most recent user action.