### PR TITLE
assets: use current pageable on hierarchy reset

### DIFF
--- a/frontend/src/content/own/Assets/index.tsx
+++ b/frontend/src/content/own/Assets/index.tsx
@@ -217,7 +217,7 @@ function Assets() {
 
   useEffect(() => {
     if (hasViewPermission(PermissionEntity.ASSETS)) {
-      handleReset(false);
+      dispatch(resetAssetsHierarchy(pageable, false));
       dispatch(getAssetChildren(0, [], pageable));
     }
   }, [pageable]);
@@ -673,7 +673,19 @@ function Assets() {
     name: Yup.string().required(t('required_asset_name'))
   };
   const handleReset = (callApi: boolean) => {
-    dispatch(resetAssetsHierarchy(callApi));
+    if (!callApi) {
+      dispatch(resetAssetsHierarchy(pageable, false));
+      return;
+    }
+
+    const resetPageable: Pageable = {
+      ...pageable,
+      page: 0,
+      size: HIERARCHY_ZERO_PAGE_SIZE
+    };
+
+    // Trigger reload through the pageable effect with initial hierarchy size.
+    setPageable(resetPageable);
   };
 
   const renderAssetAddModal = () => (

--- a/frontend/src/slices/asset.ts
+++ b/frontend/src/slices/asset.ts
@@ -295,9 +295,9 @@ export const getAssetsByPart =
   };
 
 export const resetAssetsHierarchy =
-  (callApi: boolean): AppThunk =>
+  (pageable: Pageable, callApi: boolean): AppThunk =>
   async (dispatch) => {
     dispatch(slice.actions.resetHierarchy({}));
-    if (callApi) dispatch(getAssetChildren(0, [], { page: 0, size: 10 }));
+    if (callApi) dispatch(getAssetChildren(0, [], pageable));
   };
 export default slice;


### PR DESCRIPTION
That refresh logo refresh to 10 which was causing me to refresh the entire page.   Now after hitting fetch more you can hit the refresh to go back to the beginning.  