### PR TITLE
Add date locale support to LocalizationProvider

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import router from 'src/router';
 import { SnackbarProvider } from 'notistack';
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
 import LocalizationProvider from '@mui/lab/LocalizationProvider';
+import { enUS } from 'date-fns/locale';
+import { Locale } from 'date-fns';
 import useAuth from 'src/hooks/useAuth';
 
 import { Alert, CssBaseline } from '@mui/material';
@@ -29,7 +31,7 @@ import { useTranslation } from 'react-i18next';
 import { UtmTrackerProvider } from '@nik0di3m/utm-tracker-hook';
 import { useLicenseEntitlement } from './hooks/useLicenseEntitlement';
 import { initializePaddle } from '@paddle/paddle-js';
-import { loadLanguage, supportedLanguages } from './i18n/i18n';
+import { getDateLocale, loadLanguage, supportedLanguages } from './i18n/i18n';
 import MobileAppDownloadDialog from './components/MobileAppDownloadDialog';
 import { useMobileAppPrompt } from './hooks/useMobileAppPrompt';
 
@@ -97,6 +99,7 @@ const DemoCleaningAlert = () => {
     );
   return null;
 };
+
 function App() {
   const content = useRoutes(router);
   const navigate = useNavigate();
@@ -108,9 +111,12 @@ function App() {
   const { i18n } = useTranslation();
   let location = useLocation();
   const { shouldShowPrompt, dismissPrompt } = useMobileAppPrompt();
+  const [dateFnsLocale, setDateFnsLocale] = useState<Locale>(enUS);
 
   useEffect(() => {
-    loadLanguage(i18n.language || 'en');
+    const lang = i18n.language || 'en';
+    loadLanguage(lang);
+    getDateLocale(lang).then(setDateFnsLocale);
   }, [i18n.language]);
 
   useEffect(() => {
@@ -120,6 +126,7 @@ function App() {
         page: location.pathname + location.search
       });
   }, [location]);
+
   useEffect(() => {
     const arr = location.pathname.split('/');
     if (
@@ -183,7 +190,7 @@ function App() {
   return (
     <UtmTrackerProvider customParams={['msclkid', 'ref']}>
       <ThemeProvider>
-        <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <LocalizationProvider dateAdapter={AdapterDateFns} locale={dateFnsLocale}>
           <SnackbarProvider
             maxSnack={6}
             anchorOrigin={{


### PR DESCRIPTION
**Problem**

The calendar popup in the DateTimePicker (used when setting task start/end times in work orders) was always displaying day and month names in English, regardless of the language selected by the user in Settings.

**Solution**

Refactored locale handling in `App.tsx` to be fully reactive:

- Use `useState<Locale>` initialized to `enUS`.
- Added `getDateLocale()` (already implemented in `i18n.ts`) to the existing `useEffect` that watches `i18n.language`, so the correct `date-fns` locale is loaded and applied every time the user's language changes.
- The `LocalizationProvider` now receives a reactive `dateFnsLocale` value that updates correctly on language switch.

**Languages supported**

All 16 languages supported by the app are covered: `en`, `es`, `fr`, `de`, `tr`, `pt_br`, `pl`, `ar`, `it`, `sv`, `ru`, `hu`, `nl`, `zh_cn`, `ba`, `ja`.