### PR TITLE
feat: add contractors column to work order list view

### DIFF
--- a/frontend/src/content/own/WorkOrders/index.tsx
+++ b/frontend/src/content/own/WorkOrders/index.tsx
@@ -107,6 +107,7 @@ const fieldMapping: Record<string, string> = {
   updatedAt: 'updatedAt',
   createdAt: 'createdAt',
   dueDate: 'dueDate'
+  contractors: 'contractors'
 };
 const normalizeFields = (fields: FilterField[]) =>
   [...fields]
@@ -487,6 +488,16 @@ function WorkOrders() {
         size: 170
       }
     ),
+    columnHelper.accessor((row) => row.contractors, {
+        id: 'contractors',
+        header: () => t('contractors'),
+        cell: (info) => {
+          const contractors = info.getValue();
+          if (!contractors?.length) return '';
+          return contractors.map((c) => c.companyName).join(', ');
+        },
+        size: 170
+    }),
     columnHelper.accessor((row) => row.location?.name, {
       id: 'location',
       header: () => t('location_name'),


### PR DESCRIPTION
## Problem
The work order list view does not include a "Contractors" column in the 
"Toggle columns" panel, making it impossible to see contractor assignments 
at a glance without opening each work order individually.

## Solution
Added a "Contractors" column to the work order list view that displays 
the company names of assigned contractors, consistent with how other 
assignment columns (assignedTo, teams) are handled.

## Changes
- Added `contractors` entry to `fieldMapping`
- Added `contractors` column definition to the `columns` array