### PR TITLE
Fix: Align mobile work order completion time validation with web logic

### DIFF
--- a/mobile/screens/workOrders/WODetailsScreen.tsx
+++ b/mobile/screens/workOrders/WODetailsScreen.tsx
@@ -430,7 +430,7 @@ export default function WODetailsScreen({
         name: 'completeTime',
         condition: labors
           .filter((labor) => labor.logged)
-          .some((labor) => !labor.duration),
++          .filter((labor) => labor.duration).length === 0,
         message: 'required_labor_on_completion'
       },
       {


### PR DESCRIPTION
**Problem**

The `canComplete()` function in the mobile Work Order details screen contained a logical error in the `completeTime` validation that caused inconsistent behavior compared to the web frontend.

**Buggy condition:**
```typescript
labors
  .filter((labor) => labor.logged)
  .some((labor) => !labor.duration)