### PR TITLE
Fix UI Synchronization for Numeric Inputs in Checklists

### DIFF
--- a/mobile/components/SingleTask.tsx
+++ b/mobile/components/SingleTask.tsx
@@ -43,7 +43,7 @@ export default function SingleTask({
   const { t }: { t: any } = useTranslation();
   const [savingNotes, setSavingNotes] = useState<boolean>(false);
   const { user, hasCreatePermission, hasFeature } = useAuth();
-  const [inputValue, setInputValue] = useState<string>('');
+  const [inputValue, setInputValue] = useState<string>(task.value?.toString() || '');
   const changeHandler = (newValue: string) => {
     if (!preview) {
       let formattedValue = newValue;
@@ -62,6 +62,11 @@ export default function SingleTask({
     () => debounce(changeHandler, 1000),
     []
   );
+  
+  useEffect(() => {
+  setInputValue(task.value?.toString() || '');
+}, [task.value]);
+  
   const onDropdownValueChange = (value) => {
     !preview &&
       !(task.taskBase.user && task.taskBase.user.id !== user.id) &&


### PR DESCRIPTION
**Description**

This PR addresses a UI synchronization issue in the mobile application where numeric input fields (METER and NUMBER task types) in checklists were not correctly displaying or maintaining their values.The issue was caused by the local state inputValue being decoupled from the task.value prop, leading to fields appearing empty even when data was present or successfully saved.

**Changes Made**

`mobile/components/SingleTask.tsx`

**State Initialization:** Updated `inputValue` to initialize with `task.value` instead of an empty string. This ensures that existing values are visible when the component mounts.

**Added Synchronization Hook:** Implemented a `useEffect` hook that listens for changes in the `task.value` prop and updates the local `inputValue` state accordingly. This ensures the UI stays in sync with the data source (e.g., after a successful save or when the parent component updates).