### PR TITLE
Fix: `canComplete()` ignores manually added time entries

### DIFF
--- a/mobile/screens/workOrders/WODetailsScreen.tsx
+++ b/mobile/screens/workOrders/WODetailsScreen.tsx
@@ -430,8 +430,7 @@ export default function WODetailsScreen({
         name: 'completeTime',
         condition:
           labors
-            .filter((labor) => labor.logged)
-            .filter((labor) => labor.duration).length === 0,
+            labors.filter((labor) => labor.duration > 0).length === 0,
         message: 'required_labor_on_completion'
       },
       {

--- a/mobile/screens/workOrders/WODetailsScreen.tsx
+++ b/mobile/screens/workOrders/WODetailsScreen.tsx
@@ -429,7 +429,6 @@ export default function WODetailsScreen({
       {
         name: 'completeTime',
         condition:
-          labors
             labors.filter((labor) => labor.duration > 0).length === 0,
         message: 'required_labor_on_completion'
       },


### PR DESCRIPTION
**Problem**

When a work order has **Time Logging** set as required on completion (`completeTime` field configured as `REQUIRED`), the app prevents closing the work order even after the user has added time — as long as that time was added manually via the **Add Additional Time** form.

The root cause is in `canComplete()` inside `WODetailsScreen.tsx`:

```ts
// Before — BUGGY
condition:
  labors
    .filter((labor) => labor.logged)      // only counts timer-based entries
    .filter((labor) => labor.duration).length === 0,
```

The `logged` field on the `Labor` model distinguishes between two types of time entries:

- `logged: true` → time tracked via the **built-in timer/stopwatch**
- `logged: false` → time added **manually** through the Add Additional Time form

The `canComplete()` check filters exclusively for `logged === true`, meaning any time entered manually is silently excluded from the validation count. The result is that a work order with only manually added time entries cannot be completed, even though the user has clearly logged labor.
