### PR TITLE
[Fix] Comment text not visible to mentioned users

### DIFF
--- a/mobile/components/CommentItem.tsx
+++ b/mobile/components/CommentItem.tsx
@@ -134,7 +134,7 @@ export default function CommentItem({
 
     while ((match = mentionRegex.exec(content)) !== null) {
       if (match.index > lastIndex) {
-        parts.push(content.slice(lastIndex, match.index));
+        parts.push(<Text key={key++}>{content.slice(lastIndex, match.index)}</Text>);
       }
       const [, displayName, userId] = match;
       parts.push(
@@ -155,7 +155,7 @@ export default function CommentItem({
       parts.push(content.slice(lastIndex));
     }
 
-    return parts.length > 0 ? parts : content;
+    return parts.length > 0 ? <Text>{parts}</Text> : <Text>{content}</Text>;
   };
 
   return (

--- a/mobile/components/CommentItem.tsx
+++ b/mobile/components/CommentItem.tsx
@@ -131,6 +131,7 @@ export default function CommentItem({
     const parts: ReactNode[] = [];
     let lastIndex = 0;
     let match;
+    let key = 0;
 
     while ((match = mentionRegex.exec(content)) !== null) {
       if (match.index > lastIndex) {
@@ -152,7 +153,7 @@ export default function CommentItem({
     }
 
     if (lastIndex < content.length) {
-      parts.push(content.slice(lastIndex));
+      parts.push(<Text key={key++}>{content.slice(lastIndex)}</Text>);
     }
 
     return parts.length > 0 ? <Text>{parts}</Text> : <Text>{content}</Text>;


### PR DESCRIPTION
**Problem**

When a comment contained @mentions, the surrounding plain text was not rendered for any user viewing the comment — only the mention itself (@Name) was visible.

**Root cause**

In renderContentWithMentions inside CommentItem.tsx, plain text segments were pushed into the parts array as raw strings: