### PR TITLE
Make mobile logout work when the server is unreachable

### DIFF
--- a/mobile/contexts/AuthContext.tsx
+++ b/mobile/contexts/AuthContext.tsx
@@ -832,9 +832,17 @@ export const AuthProvider: FC<AuthProviderProps> = (props) => {
   };
 
   const logout = async (): Promise<void> => {
-    await api.post('auth/logout', {});
-    setSession(null, null);
-    dispatch({ type: 'LOGOUT' });
+    try {
+      await api.post('auth/logout', {});
+    } catch {
+      // Server-side logout is best-effort; the local session is the source
+      // of truth for the device.
+    } finally {
+      // Always clear the local session, even when the server is unreachable
+      // (offline / dead zone) — otherwise the user is stuck logged in.
+      setSession(null, null);
+      dispatch({ type: 'LOGOUT' });
+    }
   };
 
   const deleteAccount = async (): Promise<void> => {


### PR DESCRIPTION
## Problem

`logout()` in `mobile/contexts/AuthContext.tsx` awaits the `auth/logout` API call before clearing the local session:

```ts
const logout = async (): Promise<void> => {
  await api.post('auth/logout', {});
  setSession(null, null);
  dispatch({ type: 'LOGOUT' });
};
```

If that call fails — device offline, expired/invalid token, or a self-hosted server that has moved or is down — the promise rejects and the local session is never cleared, so the sign-out button silently does nothing.

Because the Custom Server screen is only reachable from the logged-out flow, a user stuck in this state on a self-hosted deployment also cannot point the app at a different server. The only way out is Android's "Clear data" on the app.

We hit this in the field with a self-hosted deployment: a device connected to a decommissioned test server could neither sign out nor switch to the replacement server.

## Fix

Treat server-side logout as best-effort: attempt the API call, swallow a failure, and always clear the local session. The local session is the source of truth for the device.

## Test plan

- Sign in against a reachable server, sign out → behaves as before (server call succeeds, session cleared)
- Sign in, then make the server unreachable (airplane mode, or stop the server) → sign out now clears the session and returns to the login flow, where the Custom Server screen is reachable again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EyvTUatQCeaxXTA33qKQ4q