### PR TITLE
Permit /auth/refresh in the security filter chain

### DIFF
--- a/api/src/main/java/com/grash/configuration/WebSecurityConfig.java
+++ b/api/src/main/java/com/grash/configuration/WebSecurityConfig.java
@@ -57,6 +57,7 @@ public class WebSecurityConfig {
                         .requestMatchers("/auth/signin").permitAll()
                         .requestMatchers("/auth/signin-ldap").permitAll()
                         .requestMatchers("/auth/signup").permitAll()
+                        .requestMatchers("/auth/refresh").permitAll()
                         .requestMatchers("/auth/sso/**").permitAll()
                         .requestMatchers("/auth/sendMail").permitAll()
                         .requestMatchers("/auth/resetpwd/**").permitAll()


### PR DESCRIPTION
## Problem

`POST /auth/refresh` is not in the `permitAll()` request matchers in `WebSecurityConfig`, so the security filter chain requires an authenticated request to reach it. But a client calling refresh by definition holds only an **expired** access token — every refresh attempt is rejected with `403` (empty body) before reaching `AuthController.refresh()`, which already declares `@PreAuthorize("permitAll()")`.

Net effect on a self-hosted deployment: sessions hard-expire at the access-token TTL (~30 min). The web frontend bounces the user to sign-in, and the mobile app's writes start failing with 403 mid-shift.

Reproduce:

```
# sign in, take refreshToken from the response, then:
curl -X POST https://<server>/api/auth/refresh \
  -H 'Content-Type: application/json' \
  -d '{"refreshToken":"<fresh valid refresh token>"}'
# → 403, empty body
```

## Fix

Add `/auth/refresh` to the permitted matchers, alongside `/auth/signin` and `/auth/signup`. Refresh-token validity/rotation is still enforced inside `RefreshTokenService.rotate()`, so this does not weaken authentication — it just lets the endpoint do its job.

## Test plan

- Sign in → wait past access-token expiry (or discard it) → `POST /auth/refresh` with the refresh token → now returns a new token pair instead of 403
- Invalid/expired refresh token still rejected by `RefreshTokenService.rotate()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EyvTUatQCeaxXTA33qKQ4q