### PR TITLE
Compress photo captures so they fit the 7MB upload cap

### DIFF
--- a/mobile/components/FileUpload.tsx
+++ b/mobile/components/FileUpload.tsx
@@ -83,7 +83,7 @@ export default function FileUpload({
         mediaTypes: ImagePicker.MediaTypeOptions.Images,
         allowsMultipleSelection: multiple,
         selectionLimit: multiple ? 10 : 1,
-        quality: 1
+        quality: 0.5
       });
 
       if (!result || result.canceled) {

--- a/mobile/components/InAppCamera.tsx
+++ b/mobile/components/InAppCamera.tsx
@@ -30,7 +30,7 @@ export default function InAppCamera({ visible, onCapture, onClose }: Props) {
   const handleCapture = async () => {
     if (!cameraRef.current) return;
     try {
-      const photo = await cameraRef.current.takePictureAsync({ quality: 1 });
+      const photo = await cameraRef.current.takePictureAsync({ quality: 0.5 });
       if (photo?.uri) {
         onCapture(photo.uri);
       }


### PR DESCRIPTION
## Problem

`InAppCamera.tsx` calls `takePictureAsync({ quality: 1 })` and `FileUpload.tsx` opens the gallery picker with `quality: 1` — both uncompressed. Modern phone cameras (12–200MP) produce 8–15MB JPEGs at that setting, and `FileUpload.tsx`'s `maxFileSize = 7` check then rejects them:

> "The file size should not be more than 7 MB"

Net effect: on many current devices it is impossible to attach a photo taken with the phone — every capture fails the size check. Reproduced on a Samsung Galaxy A-series taking a work-order image.

## Fix

Request `quality: 0.5` from both the in-app camera and the gallery picker. A 12MP capture re-encodes to roughly 2–4MB — comfortably under the existing cap, with no visible quality loss for maintenance-evidence photos. The 7MB check is kept as a backstop.

## Test plan

- Take a photo with the in-app camera on a modern phone → attaches successfully instead of erroring
- Pick a photo from the gallery → compressed on selection, attaches successfully
- Existing size check still rejects oversized files (e.g. a >14MB source that stays >7MB after re-encode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EyvTUatQCeaxXTA33qKQ4q