### PR TITLE
Fix minio service: replace unavailable minio/minio image and add root user for volume compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,8 +119,9 @@ services:
       - api
 
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: alpine/minio:RELEASE.2025-10-15T17-29-55Z
     container_name: atlas_minio
+    user: "0:0"
     environment:
       MINIO_ROOT_USER: ${MINIO_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_PASSWORD}


### PR DESCRIPTION
**Summary**

minio/minio is no longer pullable from Docker Hub — the MinIO project moved to source-only distribution for the Community Edition ([minio/minio#21647](https://github.com/minio/minio/issues/21647)). This PR switches to the community-maintained alpine/minio mirror and fixes a resulting permission error on existing volumes.

**Changes**

* minio service image: minio/minio:RELEASE.2025-04-22T22-12-26Z → alpine/minio:RELEASE.2025-10-15T17-29-55Z
* Added user: "0:0" to the minio service, since existing minio_data volumes were written by the old image running as root (UID 0), and alpine/minio defaults to a non-root user, causing a startup failure (unable to rename ... file access denied).

**Testing**

* Verified existing volume file ownership is 0:0 via docker run --rm -v <volume>:/data:ro alpine ls -lan /data
* Confirmed minio starts cleanly on top of pre-existing data with no file changes or data loss
* Confirmed api and frontend connect to minio normally after the change

**Notes**

No data migration or chown was needed — this only aligns the container's runtime user with the ownership already present in the volume.